### PR TITLE
Changed button label

### DIFF
--- a/src/components/shared/minter-wizard/Navigation.tsx
+++ b/src/components/shared/minter-wizard/Navigation.tsx
@@ -106,7 +106,7 @@ export default function Navigation({
       <div className='next'>
         <SwitchTransition>
           <CSSTransition
-            key={isLastScreen ? 'Mint it!' : 'Next'}
+            key={isLastScreen ? 'Review' : 'Next'}
             addEndListener={(node, done) =>
               node.addEventListener('transitionend', done, false)
             }
@@ -120,7 +120,7 @@ export default function Navigation({
                   onClick={isLastScreen && handleGoToSummary}
                   disabled={isNextButtonHidden}
                 >
-                  Mint it!
+                  Review
                 </button>
               ) : (
                 <button


### PR DESCRIPTION
Signed-off-by: Norbert Kulus <norbert.kulus@arianelabs.com>

**Description**:
Update confusing usage of ``Mint it!`` before going to the summary screen. 
Replace it with ``Review``.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<img width="187" alt="image" src="https://user-images.githubusercontent.com/102658314/211545847-2c98680d-883b-43b1-bf0d-691f4ae83d03.png">

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
