### PR TITLE
Require edition name and image in metadata

### DIFF
--- a/src/components/views/minter-wizard/validation-schema.ts
+++ b/src/components/views/minter-wizard/validation-schema.ts
@@ -75,13 +75,14 @@ export const ValidationSchema = yup.object().shape({
     ) : (
       true
     )
-  )),
+  )).required('Required'),
   name: yup
     .string()
     .max(100, 'Too Long')
     .required('Required'),
   edition_name: yup
     .string()
+    .required('Required')
     .max(100, 'Too Long'),
   symbol: yup
     .string()


### PR DESCRIPTION
Signed-off-by: Norbert Kulus <norbert.kulus@arianelabs.com>

**Description**:
Due to an update to HIP-412, the IMAGE and NAME fields should be required.

**Related issue(s)**:

**Notes for reviewer**:
![image](https://user-images.githubusercontent.com/102658314/211560022-8126f8be-0881-40ad-94ae-6d5f53915fd4.png)

Fixes #
Add required for IMAGE and NAME fields.
<img width="651" alt="image" src="https://user-images.githubusercontent.com/102658314/211567485-345df4f2-ef2a-48bd-97c2-1d8afd62ea90.png">


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
