### PR TITLE
Set setAutoRenewAccountId() upon token creation

### DIFF
--- a/src/services/HTS.ts
+++ b/src/services/HTS.ts
@@ -102,7 +102,7 @@ export default class HTS {
       )
     });
 
-    token.setMaxTransactionFee(50).setAutoRenewAccountId(tokenProps.accountId);
+    token.setMaxTransactionFee(50).setAutoRenewAccountId(tokenProps.accountId).setAutoRenewPeriod(7776000);
 
     return token;
   }

--- a/src/services/HTS.ts
+++ b/src/services/HTS.ts
@@ -102,7 +102,7 @@ export default class HTS {
       )
     });
 
-    token.setMaxTransactionFee(50);
+    token.setMaxTransactionFee(50).setAutoRenewAccountId(tokenProps.accountId);
 
     return token;
   }


### PR DESCRIPTION
Signed-off-by: Norbert Kulus <norbert.kulus@arianelabs.com>

**Description**:
For each new NFT Collection created, set the “Auto Renew Account” to the current session’s logged in account_id. 
Example: https://mainnet-public.mirrornode.hedera.com/api/v1/tokens/0.0.697893/

**Related issue(s)**:

Fixes #
Add ``setAutoRenewAccountId(<account>)`` and ``setAutoRenewPeriod()`` to 90 days while token creation.

**Notes for reviewer**:
[Define a token](https://docs.hedera.com/hedera/docs/sdks/tokens/define-a-token)

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
