### PR TITLE
Better support for non-HIP412 compliant NFTs in Gallery

### DIFF
--- a/src/components/views/my-nft-collection/nft.scss
+++ b/src/components/views/my-nft-collection/nft.scss
@@ -32,7 +32,8 @@
     padding: 0.125rem;
     color: $vapor;
     transition: border-color 0.3s ease-in;
-
+    position: relative;
+    
     p {
       white-space: nowrap;
       overflow: hidden;
@@ -48,6 +49,26 @@
       }
     }
 
+    &__warning {
+      background: $yellow;
+      font-weight: 700;
+      z-index: 2;
+      width: 100%;
+      font-size: 0.7rem;
+      justify-content: center;
+      position: absolute;
+      top: 0;
+      left: 0;
+      align-items: center;
+      text-align: center;
+      display: flex;
+      margin: 0;
+      border-top-left-radius: 1rem;
+      border-top-right-radius: 1rem;
+      padding: 0.5rem;
+      color: $black;
+    }
+    
     &__loader {
       height: 100%;
       width: 100%;

--- a/src/utils/const/HIP412MetadataSchema.ts
+++ b/src/utils/const/HIP412MetadataSchema.ts
@@ -1,0 +1,54 @@
+/*
+ * Hedera NFT Minter App
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { isArray } from 'lodash';
+import * as yup from 'yup'
+
+const HIP412MetadataSchema = yup.object().shape({
+  name: yup.string().required(),
+  creator: yup.string(),
+  description: yup.string(),
+  image: yup.string().required(),
+  type: yup.string().required(),
+  format: yup.string(),
+  attributes: yup.array().of(
+    yup.object().shape({
+      trait_type: yup.string().required(),
+      value: yup.string().required()
+    })
+  ),
+  localization: yup.object().when('localization', {
+    is: (localization: Record<string, unknown>) => !!localization,
+    then: yup.object().shape({
+      locales: yup.mixed().test('type', 'Only image files are accepted', (value) => {
+        if (isArray(value)) {
+          return yup.array().of(
+            yup.string().required()
+          )
+        }
+
+        return yup.string().required()
+      }),
+      default: yup.string().required(),
+      uri: yup.string().required()
+    })
+  })
+}, [['localization', 'localization']]);
+
+export default HIP412MetadataSchema

--- a/src/utils/entity/NFT-Metadata.ts
+++ b/src/utils/entity/NFT-Metadata.ts
@@ -17,7 +17,7 @@
  *
  */
 
-interface FileMetadata {
+export interface FileMetadata {
   uri: string,
   type: string,
   metadata: NFTMetadata,
@@ -32,7 +32,7 @@ export interface Attribute {
   value: string,
 }
 
-interface Localization {
+export interface Localization {
   uri: string,
   locale: string,
 }

--- a/src/utils/entity/NFT-Metadata.ts
+++ b/src/utils/entity/NFT-Metadata.ts
@@ -17,7 +17,7 @@
  *
  */
 
-export interface FileMetadata {
+interface FileMetadata {
   uri: string,
   type: string,
   metadata: NFTMetadata,
@@ -32,7 +32,7 @@ export interface Attribute {
   value: string,
 }
 
-export interface Localization {
+interface Localization {
   uri: string,
   locale: string,
 }


### PR DESCRIPTION
Signed-off-by: Norbert Kulus <norbert.kulus@arianelabs.com>

**Description**:
The NFT collection (``/my-nft-collection``) crashes when linked with 0.0.8038 account. Get the following error in the logs (see attached image)
![image](https://user-images.githubusercontent.com/102658314/211564438-ef6ea239-e300-4042-b1cd-2324f53cbdca.png)

**Related issue(s)**:

**Notes for reviewer**:
Reporter seems to think it could be related to this line:
https://github.com/hashgraph/hedera-nft-minter/blob/main/src/pages/my-nft-collection.tsx#L55

Fixes #
Fixed by adding HIP-412 validation for all listed NFTs on ``/my-nft-collection`` page and label not compliant ones.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
