### PR TITLE
Update Properties syntax in metadata

### DIFF
--- a/src/utils/helpers/filterFormValuesToNFTMetadata.ts
+++ b/src/utils/helpers/filterFormValuesToNFTMetadata.ts
@@ -37,15 +37,15 @@ const reduceAttributes = (attributes: Attribute[]) => (
 
 const reduceProperties = (properties: Propertie[]) => (
   reduce(properties, (
-    res: {[key: string] : string}[],
+    res: {[key: string] : string},
     { label, value } : Propertie
   ) => {
     if (label && value) {
-      res.push({label, value})
+      res[label] = value
     }
 
     return res
-  }, [])
+  }, {})
 )
 
 const filterFormValuesToNFTMetadata = (values : FormikValues) => {

--- a/tests/utils/helpers/filterFormValuesToNFTMetadata.test.ts
+++ b/tests/utils/helpers/filterFormValuesToNFTMetadata.test.ts
@@ -33,7 +33,7 @@ describe('Filter form values to metadata', () => {
       image: 'ipfs://bafkreiahrxk5xvmuqn2jmpaj2oemm777fazloc43ltxnsivzwigxy4cyjm',
       creator: 'Tester',
       attributes: [{ trait_type: 'height', value: 10 }],
-      properties: [{ label: 'foo', value: 'bar'}]
+      properties: { foo: 'bar' }
     };
 
     expect(filterFormValuesToNFTMetadata({...values, files: ''}))
@@ -79,7 +79,7 @@ describe('Filter form values to metadata', () => {
       image: 'ipfs://bafkreiahrxk5xvmuqn2jmpaj2oemm777fazloc43ltxnsivzwigxy4cyjm',
       creator: 'Tester',
       attributes: [ { trait_type: 'foo', value: 'bar'} ],
-      properties: [ { value: 'foo', label: 'bar'} ]
+      properties: { foo: 'bar' }
     };
 
     expect(filterFormValuesToNFTMetadata({...values, files: ''}))
@@ -91,7 +91,7 @@ describe('Filter form values to metadata', () => {
         creator: 'Tester',
         format: 'HIP412@1.0.0',
         attributes: [ { trait_type: 'foo', value: 'bar'} ],
-        properties: [ { value: 'foo', label: 'bar'} ]
+        properties: { foo: 'bar' }
       });
   })
 });


### PR DESCRIPTION
Signed-off-by: Norbert Kulus <norbert.kulus@arianelabs.com>

**Description**:
Currently the Properties field is an array, but should be an object. The “label” and “value” should be removed.
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Current:
```
"properties": [
    { "label": "collection", "value": "Monkey Mixes 2022" }
  ]
```

Expected:
```
"properties":{
  "collection": "Monkey Mixes 2022"
}
```
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
